### PR TITLE
Prevent kernel panic when attaching disk with non-zero disk-timeout

### DIFF
--- a/drbd/drbd_req.c
+++ b/drbd/drbd_req.c
@@ -2467,12 +2467,14 @@ void request_timer_fn(DRBD_TIMER_FN_ARG)
 	/* FIXME right now, this basically does a full transfer log walk *every time* */
 	spin_lock_irq(&device->resource->req_lock);
 	if (dt) {
-		unsigned long write_pre_submit_jif, read_pre_submit_jif;
+		unsigned long write_pre_submit_jif = 0, read_pre_submit_jif = 0;
 		req_read = list_first_entry_or_null(&device->pending_completion[0], struct drbd_request, req_pending_local);
 		req_write = list_first_entry_or_null(&device->pending_completion[1], struct drbd_request, req_pending_local);
 
-		write_pre_submit_jif = req_write->pre_submit_jif;
-		read_pre_submit_jif = req_read->pre_submit_jif;
+		if (req_write)
+			write_pre_submit_jif = req_write->pre_submit_jif;
+		if (req_read)
+			read_pre_submit_jif = req_read->pre_submit_jif;
 		oldest_submit_jif =
 			(req_write && req_read)
 			? ( time_before(write_pre_submit_jif, read_pre_submit_jif)


### PR DESCRIPTION
Before the patch kernel panics when creating resource with non-zero disk-timeout with
[  128.868366] NULL pointer dereference at 0000000000000098
[  128.868416] IP: [<ffffffffc05f4a45>] request_timer_fn+0x6a5/0x840 [drbd] 
