### PR TITLE
Linux v5.8 compat

### DIFF
--- a/drbd/drbd-kernel-compat/cocci/__vmalloc__no_has_2_params.cocci
+++ b/drbd/drbd-kernel-compat/cocci/__vmalloc__no_has_2_params.cocci
@@ -1,0 +1,3 @@
+@@ expression S, G; @@
+- __vmalloc(S, G)
++ __vmalloc(S, G, PAGE_KERNEL)

--- a/drbd/drbd-kernel-compat/gen_patch_names.c
+++ b/drbd/drbd-kernel-compat/gen_patch_names.c
@@ -323,6 +323,9 @@ int main(int argc, char **argv)
 	patch(1, "part_stat_h", true, false,
 	      COMPAT_HAVE_PART_STAT_H, "present");
 
+	patch(1, "__vmalloc", true, false,
+	      COMPAT___VMALLOC_HAS_2_PARAMS, "has_2_params");
+
 /* #define BLKDEV_ISSUE_ZEROOUT_EXPORTED */
 /* #define BLKDEV_ZERO_NOUNMAP */
 

--- a/drbd/drbd-kernel-compat/tests/__vmalloc_has_2_params.c
+++ b/drbd/drbd-kernel-compat/tests/__vmalloc_has_2_params.c
@@ -1,0 +1,8 @@
+/* { "version": "v5.8-rc1", "commit": "88dca4ca5a93d2c09e5bbc6a62fbfc3af83c4fca", "comment": "pgprot argument to __vmalloc was removed", "author": "Christoph Hellwig <hch@lst.de>", "date": "Mon Jun 1 21:51:40 2020 -0700" } */
+
+#include <linux/vmalloc.h>
+
+void foo(void)
+{
+	__vmalloc(0, 0);
+}

--- a/drbd/drbd_bitmap.c
+++ b/drbd/drbd_bitmap.c
@@ -366,8 +366,7 @@ static struct page **bm_realloc_pages(struct drbd_bitmap *b, unsigned long want)
 	new_pages = kzalloc(bytes, GFP_NOIO | __GFP_NOWARN);
 	if (!new_pages) {
 		new_pages = __vmalloc(bytes,
-				GFP_NOIO | __GFP_HIGHMEM | __GFP_ZERO,
-				PAGE_KERNEL);
+				      GFP_NOIO | __GFP_HIGHMEM | __GFP_ZERO);
 		if (!new_pages)
 			return NULL;
 	}


### PR DESCRIPTION
Fix one build issue caused by a removed argument to __vmalloc().

There's more breakage but that is for another day:
```
cat: drbd-kernel-compat/patches/claim_disk__no_link__no_claim.patch: Datei oder Verzeichnis nicht gefunden
```