### PR TITLE
Get drbd-9.0 branch building with Linux 5.9 and 5.10

### DIFF
--- a/drbd/drbd-kernel-compat/drbd_wrappers.h
+++ b/drbd/drbd-kernel-compat/drbd_wrappers.h
@@ -127,13 +127,6 @@ static inline void blk_queue_write_cache(struct request_queue *q, bool enabled, 
 #define KREF_INIT(N) { ATOMIC_INIT(N) }
 #endif
 
-#ifdef BDI_CAP_STABLE_WRITES /* >= v3.9 */
-#define set_bdi_cap_stable_writes(cap)	do { (cap) |= BDI_CAP_STABLE_WRITES; } while (0)
-#else /* < v3.9 */
-#warning "BDI_CAP_STABLE_WRITES not available"
-#define set_bdi_cap_stable_writes(cap)	do { } while (0)
-#endif
-
 #ifdef COMPAT_HAVE_POINTER_BACKING_DEV_INFO /* >= v4.11 */
 #define bdi_from_device(device) (device->ldev->backing_bdev->bd_disk->queue->backing_dev_info)
 #else /* < v4.11 */

--- a/drbd/drbd-kernel-compat/tests/have_blkdev_get_by_path.c
+++ b/drbd/drbd-kernel-compat/tests/have_blkdev_get_by_path.c
@@ -1,4 +1,4 @@
-#include <linux/fs.h>
+#include <linux/blkdev.h>
 
 /*
  * In kernel version 2.6.38-rc1, open_bdev_exclusive() was replaced by

--- a/drbd/drbd-kernel-compat/tests/have_submit_bio.c
+++ b/drbd/drbd-kernel-compat/tests/have_submit_bio.c
@@ -1,6 +1,6 @@
 /* { "version": "v5.8", "commit": "c62b37d96b6eb3ec5ae4cbe00db107bf15aebc93", "comment": "Since 5.8 make_request_fn has been replaced by a block_device_operations method called submit_bio", "author": "Christoph Hellwig <hch@lst.de>", "date": "Wed Jul 1 10:59:43 2020 +0200" } */
 
-#include <linux/blk_types.h>
+#include <linux/blkdev.h>
 
 void foo(struct block_device_operations *ops)
 {

--- a/drbd/drbd_main.c
+++ b/drbd/drbd_main.c
@@ -16,7 +16,6 @@
 #define pr_fmt(fmt)	KBUILD_MODNAME ": " fmt
 
 #include <linux/module.h>
-#include <linux/vermagic.h>
 #include <linux/jiffies.h>
 #include <linux/drbd.h>
 #include <linux/uaccess.h>

--- a/drbd/drbd_receiver.c
+++ b/drbd/drbd_receiver.c
@@ -9390,13 +9390,10 @@ int drbd_ack_receiver(struct drbd_thread *thi)
 	unsigned int header_size = drbd_header_size(connection);
 	int expect   = header_size;
 	bool ping_timeout_active = false;
-	struct sched_param param = { .sched_priority = 2 };
 	struct drbd_transport *transport = &connection->transport;
 	struct drbd_transport_ops *tr_ops = transport->ops;
 
-	rv = sched_setscheduler(current, SCHED_RR, &param);
-	if (rv < 0)
-		drbd_err(connection, "drbd_ack_receiver: ERROR set priority, ret=%d\n", rv);
+	sched_set_fifo_low(current);
 
 	while (get_t_state(thi) == RUNNING) {
 		drbd_thread_current_set_cpu(thi);

--- a/drbd/drbd_req.c
+++ b/drbd/drbd_req.c
@@ -2196,7 +2196,7 @@ static bool drbd_fail_request_early(struct drbd_device *device, struct bio *bio)
 
 blk_qc_t drbd_submit_bio(struct bio *bio)
 {
-	struct drbd_device *device = (struct drbd_device *) q->queuedata;
+	struct drbd_device *device = bio->bi_disk->private_data;
 #ifdef CONFIG_DRBD_TIMING_STATS
 	ktime_t start_kt;
 #endif

--- a/drbd/drbd_transport_tcp.c
+++ b/drbd/drbd_transport_tcp.c
@@ -1138,7 +1138,6 @@ static int dtt_send_page(struct drbd_transport *transport, enum drbd_stream stre
 	struct drbd_tcp_transport *tcp_transport =
 		container_of(transport, struct drbd_tcp_transport, transport);
 	struct socket *socket = tcp_transport->stream[stream];
-	mm_segment_t oldfs = get_fs();
 	int len = size;
 	int err = -EIO;
 
@@ -1147,7 +1146,6 @@ static int dtt_send_page(struct drbd_transport *transport, enum drbd_stream stre
 
 	msg_flags |= MSG_NOSIGNAL;
 	dtt_update_congested(tcp_transport);
-	set_fs(KERNEL_DS);
 	do {
 		int sent;
 
@@ -1173,7 +1171,6 @@ static int dtt_send_page(struct drbd_transport *transport, enum drbd_stream stre
 		 * and add that to the while() condition below.
 		 */
 	} while (len > 0 /* THINK && peer_device->repl_state[NOW] >= L_ESTABLISHED */);
-	set_fs(oldfs);
 	clear_bit(NET_CONGESTED, &tcp_transport->transport.flags);
 
 	if (len == 0)

--- a/drbd/drbd_transport_tcp.c
+++ b/drbd/drbd_transport_tcp.c
@@ -883,7 +883,6 @@ static int dtt_connect(struct drbd_transport *transport)
 	struct socket *dsocket, *csocket;
 	struct net_conf *nc;
 	int timeout, err;
-	int one = 1;
 	bool ok;
 
 	dsocket = NULL;
@@ -1065,9 +1064,7 @@ randomize:
 	dsocket->sk->sk_sndtimeo = timeout;
 	csocket->sk->sk_sndtimeo = timeout;
 
-	err = kernel_setsockopt(dsocket, SOL_SOCKET, SO_KEEPALIVE, (char *)&one, sizeof(one));
-	if (err)
-		tr_warn(transport, "Failed to enable SO_KEEPALIVE %d\n", err);
+	sock_set_keepalive(dsocket->sk);
 
 	return 0;
 


### PR DESCRIPTION
Hey, everyone!  I had the chance to try building the latest drbd-9.0 code against the 5.9 and 5.10 kernels this afternoon.  Things almost worked.  I made a series of commits to get things compiling.  Most of it is trivial compat test changes and following along w/ what's already been done in the mainline drbd8 module to get it ready for 5.10.

I did not create a compat test for the switch from sched_setscheduler() to sched_set_fifo_low() yet.  Mostly, because I've never done that and have to wrap my head around how to add another test.  ;-)