### PR TITLE
compat: make spaas url configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ DOCKERIMAGESTARGETS = $(addprefix dockerimage.,$(DOCKERIMAGES))
 # Use the SPAAS (spatch as a service) online service
 # Have this as make variable for distributions.
 SPAAS ?= true
+SPAAS_URL ?= https://drbd.io:2020
 
 # default for KDIR/KVER
 ifndef KVER

--- a/drbd/Makefile
+++ b/drbd/Makefile
@@ -40,7 +40,9 @@ MAKEFLAGS += -rR --no-print-directory
 # Use the SPAAS (spatch as a service) online service
 # Have this as make variable for distributions.
 SPAAS ?= true
+SPAAS_URL ?= https://drbd.io:2020
 export SPAAS
+export SPAAS_URL
 
 # since 2.6.16, KERNELRELEASE may be empty,
 # e.g. when building against some (broken?) linux-header package.

--- a/drbd/drbd-kernel-compat/gen_compat_patch.sh
+++ b/drbd/drbd-kernel-compat/gen_compat_patch.sh
@@ -125,10 +125,11 @@ else
     echo "  SPAAS    $chksum"
 
     # check if SPAAS is even reachable
-    if ! curl -fsS https://drbd.io:2020/api/v1/hello; then
+    SPAAS_URL=${SPAAS_URL:-https://drbd.io:2020}
+    if ! curl -fsS $SPAAS_URL/api/v1/hello; then
         echo "  ERROR: SPAAS is not reachable! Please check if your network"
         echo "  configuration or some firewall prohibits access to "
-        echo "  https://drbd.io:2020."
+        echo "  $SPAAS_URL."
         exit 1
     fi
 
@@ -136,7 +137,7 @@ else
     rm -f $compat_patch.tmp.header $compat_patch.tmp
     if ! base64 $incdir/compat.h |
 	curl -T - -X POST -o $compat_patch.tmp -D $compat_patch.tmp.header -f \
-	    https://drbd.io:2020/api/v1/spatch/$REL_VERSION
+	    $SPAAS_URL/api/v1/spatch/$REL_VERSION
     then
 	ex=${PIPESTATUS[*]}
 	(


### PR DESCRIPTION
This PR adds SPAAS_URL configuration variable, example usage:

```
make SPAAS_URL=http://my-spaas-server:2020
```