### PR TITLE
[Docker] Skip actions if the host distro does not match the image distro

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -29,21 +29,21 @@ map_dist() {
 	return 0
 }
 
-host_dist_matches_image_dist() {	
-	host_dist="$( map_dist | cut -d'.' -f1 )"
-	if [[ -z "$host_dist" ]] ; then
-		echo "Cannot get host distro!"
-		return 1
-	fi
+host_dist_matches_image_dist() {
+       host_dist="$( map_dist | cut -d'.' -f1 )"
+       if [[ -z "$host_dist" ]] ; then
+               debug "Cannot get host distro!"
+               return 1
+       fi
 
-	image_dist="$( lbdisttool.py -l | cut -d'.' -f1 )"
-	if [[ "$host_dist" == "$image_dist" ]]; then
-		echo "The host distro matches image distro!"
-		return 0
-	else
-		echo "The host distro does not match image distro"
-		return 1
-	fi
+       image_dist="$( lbdisttool.py -l | cut -d'.' -f1 )"
+       if [[ "$host_dist" == "$image_dist" ]]; then
+               debug "The host distro matches image distro!"
+               return 0
+       else
+               debug "The host distro does not match image distro"
+               return 1
+       fi
 }
 
 print_drbd_version() {
@@ -239,18 +239,15 @@ modprobe_deps() {
 
 ### main
 
-## Skip if the linux distro of the host does not that of this image
-## Differentiate RHEL7 and RHEL8
-## Allow "exit 0", so that when used as an initContainers in Kubernetes, 
-## next initContainers with a different distro will be tried
-
+# LB_SKIP
+# allows skipping (or failing) if the linux distro of the host does not match that of this image
+# Allow "exit 0", so that when used as an initContainer in Kubernetes,
+# next initContainer with a different distro will be tried
 if [[ $LB_SKIP == yes ]]; then
-	host_dist_matches_image_dist || exit 0
+       host_dist_matches_image_dist || exit 0
 elif [[ $LB_SKIP == no ]]; then
-	host_dist_matches_image_dist || exit 1
+       host_dist_matches_image_dist || exit 1
 fi
-
-##
 
 modprobe_deps
 [[ $LB_HOW == "$HOW_DEPSONLY" ]] && { debug "dependencies loading only, exiting now"; exit 0; }

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -221,6 +221,22 @@ modprobe_deps() {
 }
 
 ### main
+
+## Skip if the linux distro of the host does not that of this image
+## Differentiate RHEL7 and RHEL8
+## Allow "exit 0", so that when used as an initContainers in Kubernetes, 
+## next initContainers with a different distro will be tried
+
+host_dist="$(lbdisttool.py -l --os-release $HOSTRELEASE | awk -F'.' '/^rhel/ {print $1}' )"
+image_dist="$(lbdisttool.py -l | awk -F'.' '/^rhel/ {print $1}' )"
+
+if [[ -z $host_dist ]] || [[ $host_dist != $image_dist ]]; then
+	echo " The distro of the host does not match that of the image"
+	[[ $LB_SKIP == yes ]] && exit 0 || exit 1
+fi
+
+##
+
 modprobe_deps
 [[ $LB_HOW == "$HOW_DEPSONLY" ]] && { debug "dependencies loading only, exiting now"; exit 0; }
 


### PR DESCRIPTION
Piraeus `kernel-module-injector` uses `entry.sh` from drbd/docker repo. 

As discussed with @WanzenBug, a good way to have Piraeus support a Kubernetes cluster with mixed Linux distros, is to have multiple `kernel-module-injector` initContainers of `piraeus-node` pods, as demonstrated in [drbd-adapter](https://github.com/alexzhc/drbd9-adapter).

Therefore, drbd containers must be able to skip actions (and exit 0) when the host distro does not match the image distro. 

Signed-off-by: alexzhc <alex.zheng@daocloud.io>