### PR TITLE
Fix incorrect grep for nsecs_to_jiffies in Kbuild.drbd

### DIFF
--- a/drbd/Kbuild.drbd
+++ b/drbd/Kbuild.drbd
@@ -15,7 +15,7 @@ LINUXINCLUDE := $(PRE_CFLAGS) -I$(src) -I$(src)/drbd-headers $(LINUXINCLUDE)
 override EXTRA_CFLAGS += -I$(src) -I$(src)/drbd-kernel-compat
 
 ifneq ($(strip $(shell \
-	grep -e '\<nsecs_to_jiffies\>' $(objtree)/Module.symvers || \
+	grep -q -e '\<nsecs_to_jiffies\>' $(objtree)/Module.symvers || \
 	grep -q -e 'EXPORT_SYMBOL(nsecs_to_jiffies)' $(srctree)/kernel/time/time.c ; \
 	echo $$?)),0)
 compat_objs += drbd-kernel-compat/nsecs_to_jiffies.o


### PR DESCRIPTION
The first grep from Module.symvers can return data causing the ifneq to get confused.