### PR TITLE
drbd: fix NULL deref in drbd_adm_prepare when resource is missing

### DIFF
--- a/drbd/drbd_nl.c
+++ b/drbd/drbd_nl.c
@@ -322,9 +322,11 @@ static int drbd_adm_prepare(struct drbd_config_context *adm_ctx,
 			err = ERR_INVALID_REQUEST;
 			goto finish;
 		}
-		adm_ctx->connection = drbd_get_connection_by_node_id(adm_ctx->resource, adm_ctx->peer_node_id);
-		if (adm_ctx->connection)
-			kref_debug_get(&adm_ctx->connection->kref_debug, 2);
+		if (adm_ctx->resource) {
+			adm_ctx->connection = drbd_get_connection_by_node_id(adm_ctx->resource, adm_ctx->peer_node_id);
+			if (adm_ctx->connection)
+				kref_debug_get(&adm_ctx->connection->kref_debug, 2);
+		}
 	} else if (flags & DRBD_ADM_NEED_PEER_NODE) {
 		drbd_msg_put_info(adm_ctx->reply_skb, "peer node id missing");
 		err = ERR_INVALID_REQUEST;


### PR DESCRIPTION
Hello DRBD maintainers,

We previously sent this patch to the drbd-dev mailing list, but it did not show up in the public archive, so we are submitting it here as well to avoid it getting lost.

This patch fixes a reproducible NULL pointer dereference in drbd_adm_prepare() when a generic netlink request provides peer_node_id but omits the resource name, leaving adm_ctx->resource unset while still attempting a connection lookup. Here is the crash report. 


```
[  442.494267][ T9467] general protection fault, probably for non-canonical address 0xdffffc0000000020: 0000 [#1] PREEMPT SMP KASAN NOPTI
[  442.495961][ T9467] KASAN: null-ptr-deref in range [0x0000000000000100-0x0000000000000107]
[  442.497112][ T9467] CPU: 1 PID: 9467 Comm: poc Tainted: G           OE      6.8.0 #2
[  442.498334][ T9467] Hardware name: QEMU Ubuntu 24.04 PC (i440FX + PIIX, 1996), BIOS 1.16.3-debian-1.16.3-2 04/01/2014
[  442.499796][ T9467] RIP: 0010:drbd_get_connection_by_node_id+0x75/0x310 [drbd]
[  442.501573][ T9467] Code: d1 1d 42 e1 58 85 ed 0f 85 db 01 00 00 e8 e3 22 42 e1 4c 8d b3 00 01 00 00 48 b8 00 00 00 00 00 fc ff df 4c 89 f2 48 c1 ea 03 <80> 3c 02 00 0f 85 7b 02 00 00 48 8b 9b 00 01 00 00 4c 39 f3 0f 84
[  442.504215][ T9467] RSP: 0018:ffffc9000624f470 EFLAGS: 00010212
[  442.505069][ T9467] RAX: dffffc0000000000 RBX: 0000000000000000 RCX: ffffc90003781000
[  442.506163][ T9467] RDX: 0000000000000020 RSI: ffffffffa04b1c8d RDI: 0000000000000001
[  442.507262][ T9467] RBP: 0000000000000001 R08: 0000000000000001 R09: 0000000000000000
[  442.508356][ T9467] R10: 0000000000000001 R11: 0000000000000002 R12: 0000000000000000
[  442.509449][ T9467] R13: ffffc9000624f55c R14: 0000000000000100 R15: 0000000000000000
[  442.510547][ T9467] FS:  00007f754b44b780(0000) GS:ffff88823bc00000(0000) knlGS:0000000000000000
[  442.511785][ T9467] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  442.512702][ T9467] CR2: 00007fb99e6efb50 CR3: 0000000036a2e000 CR4: 0000000000750ef0
[  442.513827][ T9467] PKRU: 55555554
[  442.514328][ T9467] Call Trace:
[  442.514804][ T9467]  <TASK>
[  442.515224][ T9467]  ? show_regs+0x8f/0xa0
[  442.515854][ T9467]  ? die_addr+0x4f/0xd0
[  442.516450][ T9467]  ? exc_general_protection+0x14d/0x230
[  442.517256][ T9467]  ? asm_exc_general_protection+0x26/0x30
[  442.518078][ T9467]  ? drbd_get_connection_by_node_id+0x5d/0x310 [drbd]
[  442.519777][ T9467]  ? drbd_get_connection_by_node_id+0x75/0x310 [drbd]
[  442.521486][ T9467]  drbd_adm_prepare+0xb55/0x1f40 [drbd]
[  442.523041][ T9467]  drbd_adm_new_resource+0xb3/0x560 [drbd]
[  442.524625][ T9467]  ? __pfx_drbd_adm_new_resource+0x10/0x10 [drbd]
[  442.526286][ T9467]  ? __pfx___lock_acquire+0x10/0x10
[  442.527043][ T9467]  ? __pfx___lock_acquire+0x10/0x10
[  442.527803][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.528603][ T9467]  ? __sanitizer_cov_trace_switch+0x54/0x90
[  442.529460][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.530270][ T9467]  ? __nla_validate_parse+0x11e/0x28f0
[  442.531064][ T9467]  ? __pfx___nla_validate_parse+0x10/0x10
[  442.531882][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.532691][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.533497][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.534304][ T9467]  ? __nla_parse+0x40/0x60
[  442.534955][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.535763][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.536564][ T9467]  ? genl_family_rcv_msg_attrs_parse.isra.0+0x1b4/0x290
[  442.537554][ T9467]  genl_family_rcv_msg_doit+0x200/0x2f0
[  442.538349][ T9467]  ? __pfx_genl_family_rcv_msg_doit+0x10/0x10
[  442.539217][ T9467]  ? security_capable+0x98/0xd0
[  442.539933][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.540746][ T9467]  genl_rcv_msg+0x534/0x7d0
[  442.541397][ T9467]  ? __pfx_genl_rcv_msg+0x10/0x10
[  442.542124][ T9467]  ? __pfx_drbd_adm_new_resource+0x10/0x10 [drbd]
[  442.543796][ T9467]  ? __pfx___lock_acquire+0x10/0x10
[  442.544550][ T9467]  netlink_rcv_skb+0x169/0x440
[  442.545256][ T9467]  ? __pfx_genl_rcv_msg+0x10/0x10
[  442.545981][ T9467]  ? __pfx_netlink_rcv_skb+0x10/0x10
[  442.546762][ T9467]  ? down_read+0xc0/0x330
[  442.547397][ T9467]  ? __pfx_down_read+0x10/0x10
[  442.548099][ T9467]  ? netlink_deliver_tap+0x1a0/0xd20
[  442.548867][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.549674][ T9467]  ? is_vmalloc_addr+0x86/0xa0
[  442.550356][ T9467]  genl_rcv+0x28/0x40
[  442.550939][ T9467]  netlink_unicast+0x53c/0x820
[  442.551639][ T9467]  ? __pfx_netlink_unicast+0x10/0x10
[  442.552414][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.553223][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.554029][ T9467]  ? __phys_addr_symbol+0x30/0x80
[  442.554749][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.555550][ T9467]  ? __check_object_size+0x275/0x800
[  442.556319][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.557131][ T9467]  netlink_sendmsg+0x88f/0xd30
[  442.557841][ T9467]  ? __pfx_netlink_sendmsg+0x10/0x10
[  442.558609][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.559419][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.560233][ T9467]  __sys_sendto+0x451/0x4a0
[  442.560896][ T9467]  ? __pfx___sys_sendto+0x10/0x10
[  442.561625][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.562437][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.563245][ T9467]  ? find_held_lock+0x2d/0x110
[  442.563938][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.564750][ T9467]  ? __task_pid_nr_ns+0x181/0x500
[  442.565469][ T9467]  ? __pfx_lock_release+0x10/0x10
[  442.566207][ T9467]  ? tomoyo_file_fcntl+0x72/0xc0
[  442.566928][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.567739][ T9467]  __x64_sys_sendto+0xe0/0x1c0
[  442.568426][ T9467]  ? do_syscall_64+0x93/0x230
[  442.569118][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.569928][ T9467]  ? lockdep_hardirqs_on+0x7d/0x110
[  442.570683][ T9467]  ? srso_alias_return_thunk+0x5/0xfbef5
[  442.571484][ T9467]  do_syscall_64+0xd6/0x230
[  442.572159][ T9467]  entry_SYSCALL_64_after_hwframe+0x6f/0x77
[  442.573000][ T9467] RIP: 0033:0x7f754b66055c
[  442.573626][ T9467] Code: ca f7 ff ff 44 8b 4c 24 2c 4c 8b 44 24 20 89 c5 44 8b 54 24 28 48 8b 54 24 18 b8 2c 00 00 00 48 8b 74 24 10 8b 7c 24 08 0f 05 <48> 3d 00 f0 ff ff 77 34 89 ef 48 89 44 24 08 e8 f0 f7 ff ff 48 8b
[  442.576260][ T9467] RSP: 002b:00007ffce8abb050 EFLAGS: 00000293 ORIG_RAX: 000000000000002c
[  442.577425][ T9467] RAX: ffffffffffffffda RBX: 0000000000000080 RCX: 00007f754b66055c
[  442.578521][ T9467] RDX: 00000000000000a0 RSI: 0000000000e3bb90 RDI: 0000000000000004
[  442.579614][ T9467] RBP: 0000000000000000 R08: 00007ffce8abc090 R09: 000000000000000c
[  442.580713][ T9467] R10: 0000000000000000 R11: 0000000000000293 R12: 00000000000000a0
[  442.581805][ T9467] R13: 0000000000000080 R14: 0000000000000004 R15: 00000000000000a0
[  442.582908][ T9467]  </TASK>
[  442.583340][ T9467] Modules linked in: drbd_transport_tcp(OE) drbd(OE)
[  442.584382][ T9467] ---[ end trace 0000000000000000 ]---

```


