### PR TITLE
drbd: fix ldev refcount imbalance when resync request allocation fails

### DIFF
--- a/drbd/drbd_sender.c
+++ b/drbd/drbd_sender.c
@@ -680,7 +680,6 @@ static int make_one_resync_request(struct drbd_peer_device *peer_device, int dis
 				       size, REQ_OP_WRITE);
 	if (!peer_req) {
 		drbd_err(device, "Could not allocate resync request\n");
-		put_ldev(device);
 		return -EAGAIN;
 	}
 


### PR DESCRIPTION
# Title

`put_ldev()` imbalance in `make_one_resync_request()` error path underflows `local_cnt` — permanent "ASSERTION i >= 0 FAILED in put_ldev" log flood

# Environment

- DRBD 9.3.3 (drbd-dkms 9.3.3-1), GIT-hash 97da76040a6b31aaf9e12f1a167e77ca2b3cb43e
- drbd-utils 9.34.3, LINSTOR 1.34.1, linstor-proxmox 8.3.0
- Kernel 7.0.14-4-pve (Proxmox VE), 3-node cluster
- Affected code is unchanged on current `master` (744fcf053) and present in all releases since drbd-9.2.0

# What happened

We migrated the storage of ten VM volumes to another node by running ten
`linstor resource toggle-disk --storage-pool <pool> --migrate-from <src> <node> <res>`
commands back to back. The commands return once the disk is attached, so the
resulting DRBD resyncs ran concurrently on the target node.

A few minutes into the resyncs the kernel log showed, for five of the ten volumes:

```
kernel: drbd pm-67a7d7f3/0 drbd1185: Could not allocate resync request
kernel: drbd pm-67a7d7f3/0 drbd1185: ASSERTION i >= 0 FAILED in put_ldev
kernel: drbd pm-67a7d7f3/0 drbd1185: ASSERTION i >= 0 FAILED in put_ldev
... (repeats for every I/O completion on the device, indefinitely)
```

All resyncs completed successfully (`disk:UpToDate`), but the assertion keeps
firing at the device's full I/O rate (~50/s per volume in our case, >9 million
journal lines in an hour), and only a reboot of the node clears it.

# Root cause

`make_resync_request()` takes a single ldev reference via `get_ldev()` and
releases it exactly once at `out_put_ldev`, including on the `-EAGAIN` path
(`goto request_done` → `skip_request` → `out_put_ldev`).

`make_one_resync_request()` never takes its own reference, but its allocation
error path drops one anyway (`drbd/drbd_sender.c`):

```c
	/* Do not wait if no memory is immediately available.  */
	peer_req = drbd_alloc_peer_req(peer_device, GFP_TRY & ~__GFP_RECLAIM,
				       size, REQ_OP_WRITE);
	if (!peer_req) {
		drbd_err(device, "Could not allocate resync request\n");
		put_ldev(device);          /* <-- releases the caller's reference */
		return -EAGAIN;
	}
```

So a single failed allocation results in one `get_ldev()` and two
`put_ldev()` calls, and `device->local_cnt` underflows below zero. From then
on every regular `get_ldev()`/`put_ldev()` pair decrements back to a negative
value and trips `D_ASSERT(device, i >= 0)` in `put_ldev()` — hence the flood.

The allocation failure itself is expected transient behavior: the allocation
is deliberately non-blocking (`GFP_TRY & ~__GFP_RECLAIM`), so under a burst of
parallel resyncs the mempool can run dry and the request is retried later.
The bug is only in the error path's refcounting.

Note the contrast with the checksum path `read_for_csum()`, which takes its
own `get_ldev()` and is therefore balanced when it releases one in its `defer:`
path.

Introduced by 223009b6369f ("drbd: synchronize resync with interval tree and
dagtags"), i.e. present since drbd-9.2.0.

# Impact

- Unbounded kernel log flood (one assertion per I/O completion on the
  affected device), rotating away the rest of the journal.
- `local_cnt` stays permanently skewed until the module is reloaded. The
  "last reference dropped" detection (`i == 0`) in `put_ldev()` is off by the
  underflow amount, so a later detach either never observes the counter
  reaching zero (the transition to diskless hangs) or observes zero while
  references are still in flight (use-after-free potential in the ldev
  destroy path).

# Reproduction

1. Have many volumes resync in parallel toward one node (e.g. several
   `linstor resource toggle-disk` migrations in quick succession), or
   otherwise make `drbd_alloc_peer_req()` fail in `make_one_resync_request()`
   (fault injection: `DRBD_FAULT_AL_EE` should work as well).
2. Each occurrence of "Could not allocate resync request" on a resource
   without checksum-based resync underflows `local_cnt` by one.
3. Observe "ASSERTION i >= 0 FAILED in put_ldev" on every subsequent I/O.

# Fix

Remove the stray `put_ldev()` from the allocation error path of
`make_one_resync_request()` so the reference is released exactly once, by the
caller.

## Summary

Fixes the root cause of #137.

`make_one_resync_request()` in `drbd_sender.c` does not take its own `ldev`
reference — it relies on the reference its caller, `make_resync_request()`,
already holds. Its allocation-failure path nevertheless called `put_ldev()`
before returning `-EAGAIN`. The caller handles `-EAGAIN` by falling through
to `request_done` and eventually releases its own reference at
`out_put_ldev`. So a single failed `drbd_alloc_peer_req()` call results in
one `get_ldev()` but two `put_ldev()` calls, underflowing
`device->local_cnt`.

Once negative, every following `get_ldev()`/`put_ldev()` pair on that device
trips `D_ASSERT(device, i >= 0)` in `put_ldev()` — reproducing exactly the
log flood reported in #137. It also permanently skews the "last reference
dropped" (`i == 0`) detection used to decide when a device may transition to
diskless, which can make a later detach hang, or, in the reverse case, allow
`ldev` teardown while references are still outstanding.

The allocation failure itself is expected/transient
(`GFP_TRY & ~__GFP_RECLAIM`, so it can fail under a burst of parallel
resyncs and is meant to be retried later — see the `-EAGAIN` handling in
`make_resync_request()`); only the refcounting on this path is wrong.

## Additional reproduction data (supersedes what's in #137)

We hit this again independently on 9.3.3, with full logs and source
correlation:

- Ten `linstor resource toggle-disk --migrate-from ...` migrations issued
  back to back caused ten volumes to resync concurrently on the target
  node.
- Five of the ten volumes logged "Could not allocate resync request" during
  the resync burst (mempool exhaustion under concurrent resyncs).
- Each of those five then flooded "ASSERTION i >= 0 FAILED in put_ldev" at
  the device's full I/O rate afterwards — one assertion per I/O completion,
  indefinitely, until the node was rebooted.
- All resyncs otherwise completed correctly (`disk:UpToDate`); the bug is
  confined to refcount bookkeeping, not resync correctness.

## Fix

Drop the stray `put_ldev()` from the allocation-error path of
`make_one_resync_request()` so the reference is released exactly once, by
the caller — matching the already-balanced sibling path `read_for_csum()`.

## Testing

Verified by source review and by correlating the production kernel log
against the code path (`get_ldev`/`put_ldev` call sites, `D_ASSERT` site).
Not yet build-tested against a live kernel with the patch applied´
